### PR TITLE
Fix version for kgcnn.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,5 @@ dependencies = [
         'tensorflow==2.11',
         'pymatgen',
         'pyxtal',
-        'kgcnn'
+        'kgcnn<3.1.0'
 ]


### PR DESCRIPTION
Fixed version of kgcnn. Since kgcnn 4.0 is not compatible anymore.